### PR TITLE
changed typo in word HonoInfluxDBConneCtor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Contributors:
 
 This repository contains:
 
-* HonoInfluxDBConnetor: A Spring-Boot application that connects a running Eclipse Hono instance with a running InfluxDB instance so that messages received by Hono can be stored in InfluxDB. This is especially useful if one wants to easily create a visualization of some measurements eg with Grafana.
+* HonoInfluxDBConnector: A Spring-Boot application that connects a running Eclipse Hono instance with a running InfluxDB instance so that messages received by Hono can be stored in InfluxDB. This is especially useful if one wants to easily create a visualization of some measurements eg with Grafana.
 * AppStore: A Spring-Boot application that connects a running Eclipse HawkBit instance and provides a GUI to manage vehicle (and eventually cloud) applications
 * **ONGOING** Scripts to setup the overall cloud architecture
 


### PR DESCRIPTION
Signed-off-by: Dennis Grewe <dennis.grewe@de.bosch.com>

Changed typo in the readme file for the word "HonoInfluxDBConnector"