### PR TITLE
excluded feign-hysterix from app store

### DIFF
--- a/kuksa-appstore/pom.xml
+++ b/kuksa-appstore/pom.xml
@@ -78,6 +78,12 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 			<version>2.1.0.RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.github.openfeign</groupId>
+					<artifactId>feign-hystrix</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
We exclude feign-hysterix which is imported through the spring-cloud-starter-openfeign because one of its sub-dependencies is com.google.code.findbugs:annotations (through com.netflix.archaius:archaius-core) which may have license incompatibilities with the EPL and the Eclipse Foundation.