### PR TITLE
InfluxDbConnector uses timestamp from message for write to InfluxDb

### DIFF
--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
@@ -111,8 +111,17 @@ public class InfluxDBClient implements MessageHandler {
         if (entries == null || entries.isEmpty()) {
             return;
         }
-        
-        final Point point = createPoint(System.currentTimeMillis(), msg.getDeviceID(), entries);
+
+        //check for attribute named 'time' in message and use it as timestamp for the InfluxDb
+        long timestamp;
+        Object timeObject = entries.get("time");
+        if (timeObject != null && timeObject instanceof Long) {
+            timestamp = ((Long) timeObject).longValue();
+        } else {
+            timestamp = System.currentTimeMillis();
+        }
+
+        final Point point = createPoint(timestamp, msg.getDeviceID(), entries);
 		writePoint(point);
     }
 

--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
@@ -114,7 +114,7 @@ public class InfluxDBClient implements MessageHandler {
 
         //check for attribute named 'time' in message and use it as timestamp for the InfluxDb
         long timestamp;
-        Object timeObject = entries.get("time");
+        Object timeObject = entries.get(MessageDTO.TIMESTAMP_ATTRIBUTE_NAME);
         if (timeObject != null && timeObject instanceof Long) {
             timestamp = ((Long) timeObject).longValue();
         } else {

--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageDTO.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageDTO.java
@@ -28,6 +28,9 @@ public class MessageDTO {
     /* mapping of objects within the message body */
     private final Map<String, Object> entries;
 
+    /* name of the attribute which is treated as timestamp for the InfluxDb */
+    public static final String TIMESTAMP_ATTRIBUTE_NAME = "time";
+
     /**
      * Creates a new message dto with the given device ID and mapping of the
      * message content.


### PR DESCRIPTION
The HonoInfluxDbConnector is now able to use a time attribute from the received message as timestamp in the InfluxDb. 
