### PR TITLE
Fix/update keycloak version

### DIFF
--- a/deployment/terraform/README.md
+++ b/deployment/terraform/README.md
@@ -32,6 +32,10 @@ cp ./terraform.tfvars.template ./terraform.tfvars
 ```
 Edit ```./terraform.tfvars``` according your Azure subscription.   
 
+**configure Terraform backend**
+
+This deployment stores the state of in a storage in Azure. The storage is realized through a Terraform backend which needs to be configured in the main.tf. Nore information can be found under: https://www.terraform.io/docs/backends/types/azurerm.html.
+
 **deploy infrastructure**
 ```sh
 source ./prepare_environment.sh

--- a/deployment/terraform/keycloak.tf
+++ b/deployment/terraform/keycloak.tf
@@ -42,11 +42,17 @@ resource "helm_release" "keycloak-configuration" {
   }
 }
 
+data "helm_repository" "codecentric" {
+    name = "codecentric"
+    url = "https://codecentric.github.io/helm-charts"
+}
+
 resource "helm_release" "keycloak" {
+  repository = "${data.helm_repository.codecentric.metadata.0.name}"
   name    = "keycloak"
-  chart   = "stable/keycloak"
+  chart   = "keycloak"
   timeout = 1800
-  version = "4.3.0"
+  version = "5.1.7"
   depends_on = [ "helm_release.keycloak-configuration" ]
 
   values  = [

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = ""
+    storage_account_name = ""
+    container_name       = ""
+    key                  = ""
+    access_key           = ""
+  }
+}
+
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
   subscription_id = "${var.SUBSCRIPTION_ID}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -15,9 +15,9 @@ variable "SUBSCRIPTION_ID" {
 }
 
 variable "K8S_KUBE_CONFIG" {
-  description = "Path to Kube Config File"
+  description = "Path to Kube Config File (can be created through prepare environment)"
 }
 
 variable "K8S_HELM_HOME" {
-  description = "Path to Helm Home Directory"
+  description = "Path to Helm Home Directory (e.g. under $HOME/.helm) and can be created through prepare environment.sh"
 }


### PR DESCRIPTION
The Keycloak deployment with Terraform now uses a Helm Chart published by codecentric which deployes a newer version of Keycloak. 