### PR TITLE
Add sensoris-cloud to DNS, TLS and ambassador, upgrade cert-manager

### DIFF
--- a/deployment/azure/allocate_static_ip_address_and_dns_names.sh
+++ b/deployment/azure/allocate_static_ip_address_and_dns_names.sh
@@ -98,6 +98,7 @@ allocateDomainNameForIpAddress "hawkbit"
 
 allocateDomainNameForIpAddress "kuksa-appstore"
 allocateDomainNameForIpAddress "traccar"
+allocateDomainNameForIpAddress "sensoris-cloud"
 
 allocateDomainNameForIpAddress "influxdb-rest-service"
 allocateDomainNameForIpAddress "mail-notification"

--- a/deployment/azure/resource-descriptor-templates/certificates/certificate.yaml
+++ b/deployment/azure/resource-descriptor-templates/certificates/certificate.yaml
@@ -9,7 +9,7 @@
 #
 # *****************************************************************************
 #
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: <SIMPLE_NAME>-cert
@@ -21,6 +21,8 @@ spec:
     name: <NAME_OF_CLUSTER_ISSUER>
     kind: ClusterIssuer
     namespace: cert-manager
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
   # commonName should not be longer than 64 bytes
   commonName: <SIMPLE_NAME>.<CLUSTER_NAME>.<DNS_ZONE_NAME>
   dnsNames:
@@ -40,30 +42,7 @@ spec:
   # kuksa
   - kuksa-appstore.<CLUSTER_NAME>.<DNS_ZONE_NAME>
   - traccar.<CLUSTER_NAME>.<DNS_ZONE_NAME>
+  - sensoris-cloud.<CLUSTER_NAME>.<DNS_ZONE_NAME>
   # extension
   - influxdb-rest-service.<CLUSTER_NAME>.<DNS_ZONE_NAME>
   - mail-notification.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-  acme:
-    config:
-    - dns01:
-        provider: azure
-      domains:
-      - gateway.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      # hono
-      - grafana.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-adapter-amqp-vertx.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-adapter-http-vertx.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-adapter-kura.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-adapter-mqtt-vertx.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-dispatch-router.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-service-device-registry.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - hono-service-messaging.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - influxdb.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      # hawkbit
-      - hawkbit.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      # kuksa
-      - kuksa-appstore.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - traccar.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      # extension
-      - influxdb-rest-service.<CLUSTER_NAME>.<DNS_ZONE_NAME>
-      - mail-notification.<CLUSTER_NAME>.<DNS_ZONE_NAME>

--- a/deployment/azure/resource-descriptor-templates/cluster-issuers/letsencrypt-prod-clusterissuer-dns01.yaml
+++ b/deployment/azure/resource-descriptor-templates/cluster-issuers/letsencrypt-prod-clusterissuer-dns01.yaml
@@ -10,7 +10,7 @@
 # *****************************************************************************
 #
 
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 # A ClusterIssuer is used instead of an issuer because unlike an issuer
 # it can create certificates in other namespaces than its own.
 kind: ClusterIssuer
@@ -23,21 +23,20 @@ spec:
     email: <EMAIL_ADDRESS_FOR_LETS_ENCRYPT>
     privateKeySecretRef:
       name: letsencrypt-prod
-    dns01:
-        providers:
-            - name: azure
-              azuredns:
-                # Service principal clientId (also called appId)
-                clientID: <APP_ID_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
-                # A secretKeyRef to a service principal ClientSecret (password)
-                # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
-                clientSecretSecretRef:
-                  name: <NAME_OF_SECRET_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
-                  key: CLIENT_SECRET
-                # Azure subscription Id
-                subscriptionID: <AZURE_SUBSCRIPTION_ID>
-                # Azure AD tenant Id
-                tenantID: <AZURE_AD_TENANT_ID>
-                # ResourceGroup name where dns zone is provisioned
-                resourceGroupName: <ZONE_RESOURCE_GROUP_NAME>
-                hostedZoneName: <DNS_ZONE_NAME>
+    solvers:
+      - dns01:
+          azuredns:
+            # Service principal clientId (also called appId)
+            clientID: <APP_ID_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
+            # A secretKeyRef to a service principal ClientSecret (password)
+            # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
+            clientSecretSecretRef:
+              name: <NAME_OF_SECRET_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
+              key: CLIENT_SECRET
+            # Azure subscription Id
+            subscriptionID: <AZURE_SUBSCRIPTION_ID>
+            # Azure AD tenant Id
+            tenantID: <AZURE_AD_TENANT_ID>
+            # ResourceGroup name where dns zone is provisioned
+            resourceGroupName: <ZONE_RESOURCE_GROUP_NAME>
+            hostedZoneName: <DNS_ZONE_NAME>

--- a/deployment/azure/resource-descriptor-templates/cluster-issuers/letsencrypt-staging-clusterissuer-dns01.yaml
+++ b/deployment/azure/resource-descriptor-templates/cluster-issuers/letsencrypt-staging-clusterissuer-dns01.yaml
@@ -10,7 +10,7 @@
 # *****************************************************************************
 #
 
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 # A ClusterIssuer is used instead of an issuer because unlike an issuer
 # it can create certificates in other namespaces than its own.
 kind: ClusterIssuer
@@ -23,21 +23,20 @@ spec:
     email: <EMAIL_ADDRESS_FOR_LETS_ENCRYPT>
     privateKeySecretRef:
       name: letsencrypt-staging
-    dns01:
-        providers:
-            - name: azure
-              azuredns:
-                # Service principal clientId (also called appId)
-                clientID: <APP_ID_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
-                # A secretKeyRef to a service principal ClientSecret (password)
-                # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
-                clientSecretSecretRef:
-                  name: <NAME_OF_SECRET_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
-                  key: CLIENT_SECRET
-                # Azure subscription Id
-                subscriptionID: <AZURE_SUBSCRIPTION_ID>
-                # Azure AD tenant Id
-                tenantID: <AZURE_AD_TENANT_ID>
-                # ResourceGroup name where dns zone is provisioned
-                resourceGroupName: <ZONE_RESOURCE_GROUP_NAME>
-                hostedZoneName: <DNS_ZONE_NAME>
+    solvers:
+      - dns01:
+          azuredns:
+            # Service principal clientId (also called appId)
+            clientID: <APP_ID_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
+            # A secretKeyRef to a service principal ClientSecret (password)
+            # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
+            clientSecretSecretRef:
+              name: <NAME_OF_SECRET_OF_SERVICE_PRINCIPAL_WITH_ACCESS_TO_AZURE_DNS>
+              key: CLIENT_SECRET
+            # Azure subscription Id
+            subscriptionID: <AZURE_SUBSCRIPTION_ID>
+            # Azure AD tenant Id
+            tenantID: <AZURE_AD_TENANT_ID>
+            # ResourceGroup name where dns zone is provisioned
+            resourceGroupName: <ZONE_RESOURCE_GROUP_NAME>
+            hostedZoneName: <DNS_ZONE_NAME>

--- a/deployment/kubernetes/ambassador/ambassador-service.yaml
+++ b/deployment/kubernetes/ambassador/ambassador-service.yaml
@@ -146,6 +146,14 @@ metadata:
       host: traccar.<CLUSTER_NAME>.<DNS_ZONE_NAME>
       service: traccar.kuksa.svc.cluster.local:5055
       ---
+      apiVersion: ambassador/v1
+      kind: TCPMapping
+      name: sensoris-cloud-mapping
+      port: 9000
+      host: sensoris-cloud.<CLUSTER_NAME>.<DNS_ZONE_NAME>
+      service: sensoris-cloud.kuksa.svc.cluster.local:9000
+      tls: true
+      ---
       # extension
       apiVersion: ambassador/v1
       kind: TCPMapping
@@ -181,6 +189,7 @@ metadata:
       # kuksa
       - kuksa-appstore.<CLUSTER_NAME>.<DNS_ZONE_NAME>
       - traccar.<CLUSTER_NAME>.<DNS_ZONE_NAME>
+      - sensoris-cloud.<CLUSTER_NAME>.<DNS_ZONE_NAME>
       # extension
       - influxdb-rest-service.<CLUSTER_NAME>.<DNS_ZONE_NAME>
       - mail-notification.<CLUSTER_NAME>.<DNS_ZONE_NAME>
@@ -206,6 +215,8 @@ spec:
      port: 8443
    - name: mqtts
      port: 8883
+   - name: wss
+     port: 9000
   selector:
     app.kubernetes.io/instance: ambassador
     app.kubernetes.io/name: ambassador


### PR DESCRIPTION
Cert-manager resources are upgraded to be compatible to cert-manager
0.12. The installation of cert-manager and ambassador has been removed
from the scripts because it changes more often that it is used.

Signed-off-by: Sebastian Lohmeier (INST-CSS/BSV-OS1) <Sebastian.Lohmeier@bosch-si.com>