### PR TITLE
Add resource limits in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,13 @@ spec:
     command:
     - cat
     tty: true
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "1"
+      limits:
+        memory: "2Gi"
+        cpu: "1"
 """
     }
   }


### PR DESCRIPTION
Previously, builds failed due to lack of memory, e.g.
https://ci.eclipse.org/kuksa/job/kuksa.cloud/job/master/37/console

Signed-off-by: Sebastian Lohmeier (INST-CSS/BSV-OS1) <Sebastian.Lohmeier@bosch-si.com>