### PR TITLE
Dependencies: replace hibernate-validator by javax-validation

### DIFF
--- a/kuksa-appstore/pom.xml
+++ b/kuksa-appstore/pom.xml
@@ -162,6 +162,17 @@
 			<groupId>org.vaadin.spring.extensions</groupId>
 			<artifactId>vaadin-spring-ext-boot</artifactId>
 			<version>2.0.0.RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.hibernate.validator</groupId>
+					<artifactId>hibernate-validator</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.vaadin.spring.extensions</groupId>


### PR DESCRIPTION
Hibernate-validator is GPL'ed while javax-validation has Apache License
2.0 according to
https://search.maven.org/artifact/javax.validation/validation-api/2.0.1.Final/jar

Signed-off-by: Sebastian Lohmeier (INST-CSS/BSV-OS1) <Sebastian.Lohmeier@bosch-si.com>