### PR TITLE
adds initial Helm chart for Eclipse Kuksa

### DIFF
--- a/deployment/helm/Readme.md
+++ b/deployment/helm/Readme.md
@@ -1,0 +1,24 @@
+# Kuksa Cloud Helm Chart
+This helm chart can be used to deploy components of the Kuksa Cloud to Kubernetes cluster. The chart is developed for Helm 3. To do a deployment you need to perform the following steps:
+- 1. build and push the Kuksa components to a private container registry and add the credentials to the values.yaml file under `imageCredentials`
+- 2. fetch the dependencies of the chart by running: 
+
+```bash
+helm dep up ./kuksa-cloud
+```
+- 3. install/release the chart by running:
+```bash
+helm install <release name> ./kuksa-cloud
+```
+If you want to deploy to another namespace than default use:
+```bash 
+helm install <release name>  ./kuksa-cloud -n <namespace>
+```
+
+## Values
+The Kuksa Cloud has multiple dependencies and components. Depending on the use case it is possible that one might not need all of them. In the `values.yaml` it is possible to control that a component should not be deployed by setting the entry `components.<name of component>.enabled` to `false`. 
+
+### Hono-InfluxDB-Connector
+On part of the Kuksa Cloud that is developed within the Kuksa project is the Hono-InfluxDB-Connector. More information on the connector can be found in the [respective folder](../../utils/hono-influxdb-connector/README.md). Within the `values.yaml` of this chart it is possible to configure the connector with the values under 'connector'. Note that the list in `connections` can be extended by maps with similar key as the ones in the default `values.yaml`.
+
+In most cases it takes some time for the InfluxDB to start. Because the connector is not able to connect to the database during that start time, there might happen several restarts of the connector. In most cases the connector pod becomes stable after 3 to 5 restarts. Alternatively, it might help to manually delete the pod once the InfluxDB Pod becomes ready and then to wait for the automatic creation of a new connector pod. 

--- a/deployment/helm/kuksa-cloud/Chart.yaml
+++ b/deployment/helm/kuksa-cloud/Chart.yaml
@@ -1,0 +1,48 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+---
+apiVersion: v2
+name: kuksa-cloud
+description: A Helm chart for deploying the core parts of the Eclipse Kuksa cloud to a Kubernetes instance. The Eclipse Kuksa cloud consists of the following parts Eclipse Hono, Eclipse hawkBit, Keycloak, InfluxDb, Kuksa Hono-to-InfluxDb-Connector.
+
+home: https://eclipse.org/kuksa
+#sources: https://github.com/eclipse/kuksa.cloud
+keywords: 
+    - IoT
+    - Kuksa
+    - Connected Vehicle
+    - Connected Driving
+type: application
+
+version: 0.0.1
+apiVersion: v2
+appVersion: 0.2.0
+maintainers:
+    - name: eriksven
+      email: svenerik.jeroschewski@bosch.io
+
+dependencies:
+    - name: hono
+      version: ~1.1.3
+      repository: https://eclipse.org/packages/charts
+      condition: components.hono.enabled
+    - name: influxdb
+      version: ~4.4.8
+      repository: https://helm.influxdata.com/
+      condition: components.influxdb.enabled
+    - name: hawkbit
+      version: ~1.2.2
+      repository: https://eclipse.org/packages/charts
+      condition: components.hawkbit.enabled
+    - name: keycloak
+      version: ~8.0.0
+      repository: https://codecentric.github.io/helm-charts
+      condition: components.keycloak.enabled
+

--- a/deployment/helm/kuksa-cloud/templates/NOTES.txt
+++ b/deployment/helm/kuksa-cloud/templates/NOTES.txt
@@ -1,0 +1,2 @@
+Congratulations!
+You succesfully deployed a release of the Eclipse Kuksa Cloud.

--- a/deployment/helm/kuksa-cloud/templates/configmap-connector.yaml
+++ b/deployment/helm/kuksa-cloud/templates/configmap-connector.yaml
@@ -1,0 +1,26 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{.Release.Name}}-connector-configmap"
+data: 
+  INFLUXDB_URL: "http://{{.Release.Name}}-influxdb.{{.Release.Namespace}}.svc.cluster.local:8086"
+  QPID_ROUTER_HOST: "{{.Release.Name}}-dispatch-router-ext.{{.Release.Namespace}}.svc.cluster.local"
+  QPID_ROUTER_PORT: {{quote .Values.connector.qpidRouterPort}}
+  HONO_TRUSTEDSTOREPATH: {{quote .Values.connector.honoTrustedStorePath}}
+  HONO_VERIFYHOSTNAME: "{{.Values.connector.honoVerifyHostname}}"
+  {{- range $index, $item := .Values.connector.connections}}
+    {{- range $key, $value := $item}}
+  HONO_CONNECTIONS_{{ $index }}_{{ $key | upper }} : {{ $value }}
+    {{- end}}
+  {{- end}}
+  LOGGING_LEVEL_ROOT: {{quote .Values.connector.loggingLevel }}
+  

--- a/deployment/helm/kuksa-cloud/templates/deployment-connector.yaml
+++ b/deployment/helm/kuksa-cloud/templates/deployment-connector.yaml
@@ -1,0 +1,48 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .Release.Name }}-connector"
+  #namespace: hono
+  labels:
+    app: hono-influxdb-connector
+    version: {{ .Chart.AppVersion }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-connector
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-connector
+        version: {{ .Chart.AppVersion }}
+    spec:
+      containers:
+      - image: "{{ .Values.imageCredentials.registry }}/{{.Values.connector.image}}:{{ .Chart.AppVersion }}"
+        name: "{{ .Release.Name }}-connector"
+        imagePullPolicy: {{ .Values.connector.imagePullPolicy }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-connector-configmap
+        - secretRef:
+            name: {{ .Release.Name }}-connector-secret
+        volumeMounts:
+        - mountPath: /etc/hono
+          name: config
+          readOnly: true
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ .Release.Name}}-dispatch-router-conf
+      imagePullSecrets:
+        - name: docker-secret

--- a/deployment/helm/kuksa-cloud/templates/docker-secret.yaml
+++ b/deployment/helm/kuksa-cloud/templates/docker-secret.yaml
@@ -1,0 +1,16 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}"

--- a/deployment/helm/kuksa-cloud/templates/secret-connector.yaml
+++ b/deployment/helm/kuksa-cloud/templates/secret-connector.yaml
@@ -1,0 +1,17 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-connector-secret"
+type: Opaque
+data:
+  HONO_USER: "{{- printf .Values.connector.honoUser | b64enc}}"
+  HONO_PASSWORD: "{{- printf .Values.connector.honoPassword | b64enc }}"

--- a/deployment/helm/kuksa-cloud/values.yaml
+++ b/deployment/helm/kuksa-cloud/values.yaml
@@ -1,0 +1,50 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+# credentials for the registry hosting privat container images (e.g. Hono-InfluxDB-Connector)
+imageCredentials:
+  registry: 
+  username: 
+  password: 
+
+# configure the Hono-InfluxDB-Connector
+connector:
+  # The name of the container image for the connector. Note that the address of the container registry under imageCredentials.registry is added as prefix and that the image should be tagged with the App version of this chart.
+  image: hono-influxdb-connector
+  imagePullPolicy: Always
+  qpidRouterPort: 15671
+  honoTrustedStorePath: /etc/hono/trusted-certs.pem
+  honoVerifyHostname: false
+  # The credentials for the dispatch router endpoint in Eclipse Hono. The default values in this chart are also the default credentials for that endpoint.
+  honoUser: consumer@HONO
+  honoPassword: verysecret
+  loggingLevel: INFO
+  # This part can be used to configure the connections on which the connector will listen. The 'tenantId' indicates the tenant in Eclipse Hono on which the connector will connect. The connector then writes all messages received from the respective tenant to the database specified in 'influxDatabaseName'. 
+  connections:
+    - tenantId: tenant1
+      influxDatabaseName: tenant1-data
+    - tenantId: tenant2
+      influxDatabaseName: tenant2-data
+
+# control which dependencies should be deployed (enabled: true)
+components:
+  hono:
+    enabled: true
+  influxdb:
+    enabled: true
+  hawkbit:
+    enabled: false
+  keycloak:
+    enabled: false
+
+# configure the values from the Eclipse Hono Helm chart fetched from https://github.com/eclipse/packages/tree/master/charts/hono)
+hono:
+  adapters:
+    amqp:
+      enabled: false


### PR DESCRIPTION
An initial Helm Chart for the cloud backend of Eclipse Kuksa. This chart deploys Eclipse Hono, an InfluxDB and the Hono-InfluxDB-Connector. It is further possible to deploy Eclipse hawkBit and Keycloak too. This PR is one step for resolving #108 . 