### PR TITLE
adds Ambassador to Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ deployment/exportStaticIpAddresses.inc
 
 # Kubernetes resources derived from Eclipse hawkBit helm chart
 deployment/eclipse-hawkbit/base/hawkbit/
+
+#MacOS file
+.DS_Store
+
+#Helm
+deployment/helm/kuksa-cloud/charts
+deployment/helm/kuksa-cloud/Chart.lock

--- a/deployment/helm/Readme.md
+++ b/deployment/helm/Readme.md
@@ -47,3 +47,30 @@ to get an overview of all available services. To change the service type of Keyc
 Notes:
 - All addresses (app store and Keycloak) need to be accessible from the user's machine which in most scnearios means that they should be reachable from the internet.
 - If the redirect after the login back to the app store fails with an error like `too many redirects`, the reason could be that the app store has a wrong secret configured. 
+
+# TLS with Cert Manager and Ambassador
+To enable users to access the Kuksa Cloud services with a single IP-address, the Cloud makes use of the [Ambassador](https://www.getambassador.io) project as API gateway. 
+The Ambassador allows the routing on the TCP layer. To signal which service one wants to call one can specify the port. The default configuration has the following port mappings. Note, that some of the ports are not a standard port because some of the services share the same default port. 
+
+
+| Service               | Port on Ambassador (external)  | Port on Pod (internal) |
+|-----------------------|-------|-------|
+| Grafana | 3000  | 3000 |
+| InfluxDB | 8086  | 8086 |
+| Hono Dispatch Router | 5671 | 15671 |
+| MQTT Adapter | 1883 | 1883 |
+| HTTP Adapter | 18080 | 18080 |
+| Hono Device Registry | 28080 | 28080 |
+| hawkBit | 38080 | 80 |
+| Keycloak | 48080 | 80 |
+| App Store | 58080 | 8080 |
+
+
+
+
+
+The decision which service is called, is signalled through the SNI field in the used certificates. 
+For the creation of these certificates the Kuksa Clouds relies on an instance of the [cert-manager](https://cert-manager.io). 
+
+The cert-manager requires so-called custom resource definitions (CRD) which are not installed as part of the Helm chart. To install the CRDs before installing the Helm chart one needs to run: `kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml`
+

--- a/deployment/helm/kuksa-cloud/.helmignore
+++ b/deployment/helm/kuksa-cloud/.helmignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/deployment/helm/kuksa-cloud/Chart.yaml
+++ b/deployment/helm/kuksa-cloud/Chart.yaml
@@ -45,4 +45,8 @@ dependencies:
       version: ~8.0.0
       repository: https://codecentric.github.io/helm-charts
       condition: components.keycloak.enabled
-
+    - name: ambassador
+      version: ~6.4.5
+      repository: https://www.getambassador.io
+      condition: components.ambassador.enabled
+   

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-appstore.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-appstore.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-app-store
+spec:
+  port: 58080
+  service: {{.Release.Name}}-app-store:8080
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-device-registry.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-device-registry.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{ .Release.Name }}-device-registry
+spec:
+  port: 28080
+  service: {{.Release.Name}}-device-registry-ext:28080
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-dispatch-router.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-dispatch-router.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-dispatch-router
+spec:
+  port: 5671
+  service: {{.Release.Name}}-dispatch-router-ext:15671
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-grafana.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-grafana.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-grafana
+spec:
+  port: 3000
+  service: {{.Release.Name}}-grafana:3000
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-hawkbit.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-hawkbit.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-hawkbit
+spec:
+  port: 38080
+  service: {{.Release.Name}}-hawkbit:80
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-adapter.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-adapter.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-http-adapter
+spec:
+  port: 18080
+  service: {{.Release.Name}}-adapter-http-vertx:8080
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-influxdb.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-influxdb.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-influxdb
+spec:
+  port: 8086
+  service: {{.Release.Name}}-influxdb:8086
+  {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-keycloak.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-keycloak.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{- if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-keycloak
+spec:
+  port: 48080
+  service: {{.Release.Name}}-keycloak-http:80
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-mqtt-adapter.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-mqtt-adapter.yaml
@@ -1,0 +1,18 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{ if .Values.components.ambassador.enabled }}
+apiVersion: getambassador.io/v2
+kind:  TCPMapping
+metadata:
+  name:  {{.Release.Name}}-adapter-mqtt
+spec:
+  port: 1883
+  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+{{end}}

--- a/deployment/helm/kuksa-cloud/values.yaml
+++ b/deployment/helm/kuksa-cloud/values.yaml
@@ -36,7 +36,7 @@ connector:
 appstore:
   image: kuksa-appstore
   service:
-    type: LoadBalancer
+    type: ClusterIP
   credentials: 
     username: admin
     password: admin
@@ -66,9 +66,12 @@ components:
     enabled: true
   keycloak:
     enabled: true
+  ambassador:
+    enabled: true
 
 # configure the values from the Eclipse Hono Helm chart fetched from https://github.com/eclipse/packages/tree/master/charts/hono
 hono:
+  useLoadBalancer: false
   adapters:
     amqp:
       enabled: false
@@ -81,4 +84,23 @@ keycloak:
     username: keycloak
     password: admin
     service:
-      type: LoadBalancer
+      type: ClusterIP
+
+ambassador:
+  replicaCount: 2
+  enableAES: false
+  image:
+      repository: docker.io/datawire/ambassador
+  service:
+    ports: [{"name": "http","port": 80,"targetPort": 8080},{"name": "https","port": 443,"targetPort": 8443},{"name": "grafana","port": 3000,"targetPort": 3000}, {"name": "hawkbit","port": 38080,"targetPort": 38080}, {"name": "influxdb","port": 8086,"targetPort": 8086}, {"name": "keycloak","port": 48080,"targetPort": 48080}, {"name": "mqtt-adapter","port": 1883,"targetPort": 1883}, {"name": "http-adapter","port": 18080,"targetPort": 18080}, {"name": "app-store","port": 58080,"targetPort": 58080}, {"name": "dispatch-router","port": 5671,"targetPort": 15671}, {"name": "device-registry","port": 28080,"targetPort": 28080}]
+    http:
+      enabled: true
+      port: 80
+      targetPort: 80
+    https:
+      port: 8443
+      targetPort: 8443
+    loadBalancerIP: localhost
+    # The annotations are specific to the Cloud provider (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer ). The default annotation in this chart is suited for Azure to allow the assignment of an Azure managed IP-address to the LoadBalancer service of the Ambassador. One needs to replace "kuksa" with the actual name of the resource group of the IP-address assigned in 'loadBalancerIP' and allow the service principle for the AKS to access the IP-address. For more information see https://docs.microsoft.com/en-us/azure/aks/static-ip. 
+    annotations: 
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: "kuksa"


### PR DESCRIPTION
adds Ambassador to Helm chart. The service selection happens via specifying a port since the routing happens on the TCP layer. 