### PR TITLE
adds cert-manager to Helm deployment

### DIFF
--- a/deployment/helm/Readme.md
+++ b/deployment/helm/Readme.md
@@ -1,6 +1,6 @@
 # Kuksa Cloud Helm Chart
-This helm chart can be used to deploy components of the Kuksa Cloud to Kubernetes cluster. The chart is developed for Helm 3. To do a deployment you need to perform the following steps:
-- 1. build and push the Kuksa components to a private container registry and add the credentials to the values.yaml file under `imageCredentials`
+This helm chart can be used to deploy the main components of the Kuksa Cloud to a Kubernetes cluster. The chart is developed for Helm 3. For an overview of the different deployable components see below. To do a deployment you need to perform the following steps:
+- 1. build and push the Kuksa specifc containers to a private container registry and add the credentials to the values.yaml file under `imageCredentials`
 - 2. fetch the dependencies of the chart by running: 
 
 ```bash
@@ -10,29 +10,29 @@ helm dep up ./kuksa-cloud
 ```bash
 helm install <release name> ./kuksa-cloud
 ```
-If you want to deploy to another namespace than default use:
+If you want to deploy to another namespace than `default` use:
 ```bash 
 helm install <release name>  ./kuksa-cloud -n <namespace>
 ```
 
-## Values
+## Values and Components
 The Kuksa Cloud has multiple dependencies and components. Depending on the use case it is possible that one might not need all of them. In the `values.yaml` it is possible to control that a component should not be deployed by setting the entry `components.<name of component>.enabled` to `false`. 
 
 ### Hono-InfluxDB-Connector
-On part of the Kuksa Cloud that is developed within the Kuksa project is the Hono-InfluxDB-Connector. More information on the connector can be found in the [respective folder](../../utils/hono-influxdb-connector/README.md). Within the `values.yaml` of this chart it is possible to configure the connector with the values under 'connector'. Note that the list in `connections` can be extended by maps with similar key as the ones in the default `values.yaml`.
+On part of the Kuksa Cloud that is developed within the Kuksa project is the Hono-InfluxDB-Connector. More information on the connector can be found in the [respective folder](../../utils/hono-influxdb-connector/README.md). In short, the connector accepts data from Elipse Hono (northbound AMQP 1.0 API) and writes it to an InfluxDB. Within the `values.yaml` of this chart it is possible to configure the connector with the values under 'connector'. Note that the list in `connections` can be extended by maps with similar key as the ones in the default `values.yaml`.
 
 In most cases it takes some time for the InfluxDB to start. Because the connector is not able to connect to the database during that start time, there might happen several restarts of the connector. In most cases the connector pod becomes stable after 3 to 5 restarts. Alternatively, it might help to manually delete the pod once the InfluxDB Pod becomes ready and then to wait for the automatic creation of a new connector pod. 
 
 ### App Store
-The App Store is an applications that allows owners to manage the applications on their vehicle. Most common operations are the command to start the installation or deletion process of an app on the vehicle. The  management of the applications is handled by hawkBit. The users are handled by a Keycloak instance. 
+The App Store is an applications that allows owners to manage the applications on their vehicle/device. Most common operations are the command to start the installation or deletion process of an app on the vehicle. The  management of the applications is handled by hawkBit. The users are handled by a Keycloak instance. 
 
 #### Configuring the App Store
-One way to open the app store is to access the public ip-address of the respective service (`releasename-appstore`) on port `8080`. The app store then redirects the owners to the Keycloak instance. In the next step the user logs in with Keycloak and then Keycloak redirects the authenticated user back to the application which in this case is the app store. To make this process work a number administration steps are necessary:
+One way to open the app store is to access the public ip-address of the respective service (`releasename-appstore`) on port `8080`. Since Keylcoak handles the login, the app store then needs to redirect the user to the Keycloak instance. In the next step the user logs in with Keycloak and then Keycloak redirects the authenticated user back to the application which in this case is the app store. To make this process work a number administration and configuration steps are necessary:
 
 1. Set the admin credentials for Keycloak in the `values.yaml` file of the overall Helm chart under `keycloak` (`username`and `password`). Note that the default username is `keycloak` and that the Keycloak chart generates a random password if no password is explicitly set.
-2. To configure Keycloak open the Admin-UI of Keycloak. This can be done by using the public ip-address of the Keycloak service (`{releasename}-keycloak-http`). Use 
+2. To configure Keycloak select "Administration Console" on the Keycloak welcome page and login with the admin credentials from step 1. . One can access the the welcome page by using the public ip-address either of the Ambassdor gateway (see below) or of the Keycloak service (`{releasename}-keycloak-http`) itself. For the second option use 
 ```kubectl get svc -n {namespace} {releasename}-keycloak-http``` 
-to get an overview of all available services. To change the service type of Keycloak and thus get a public ip-address for Keycloak one can set the service type to `LoadBalancer`in the `keycloak.keycloak.service.type` value. After opening the Keycloak endpoint select "Administration Console" on the Keycloak welcome page and login with the admin credentials from step 1.
+to get an overview of all available services. To change the service type of Keycloak and thus get an individual public ip-address for Keycloak one can set the service type to `LoadBalancer`in the `keycloak.keycloak.service.type` value. 
 3. Create a new realm in Keycloak (e.g. app-store) with the "Add realm" button which becomes visible when one does a moser over over the name of the current realm. By default the current realm is "Master".
 4. Click on "Select file" next to "Import" and import a preconfigured Keycloak configuration (e.g. from `kuksa-cloud/realm-export-app-store.json`). Finish this step by clicking on the "Create" button.
 5. Create a user in the created realm and assign it at least the roles: `offline_access`, `ROLE_ADMIN`, `ROLE_USER`, `uma_authorization`. For regular app store user one should leave out the `ROLE_ADMIN` role. To create a new user go to "Users" and then click "Add user" in the top of the user overview. To change the role assignment, go to the user and then select `Role Mappings`. One should also set a password for the user in the "Credentials" tab.
@@ -48,9 +48,9 @@ Notes:
 - All addresses (app store and Keycloak) need to be accessible from the user's machine which in most scnearios means that they should be reachable from the internet.
 - If the redirect after the login back to the app store fails with an error like `too many redirects`, the reason could be that the app store has a wrong secret configured. 
 
-# TLS with Cert Manager and Ambassador
-To enable users to access the Kuksa Cloud services with a single IP-address, the Cloud makes use of the [Ambassador](https://www.getambassador.io) project as API gateway. 
-The Ambassador allows the routing on the TCP layer. To signal which service one wants to call one can specify the port. The default configuration has the following port mappings. Note, that some of the ports are not a standard port because some of the services share the same default port. 
+# Ambassador Gateway
+In theory, one could provision an ip-address for each service of the Kuksa cloud which one wants to access from the internet. However, ip-addresses are limited and may add addtional cost. To enable users to access the Kuksa Cloud services with a single IP-address, the Cloud makes use of the [Ambassador](https://www.getambassador.io) project as API gateway. 
+The Ambassador allows the routing on the TCP and the HTTP layer. The Kuksa Cloud requires the TCP based routing because it uses a number of non-HTTP protocols such as MQTT or AMQP 1.0. To signal which service one wants to call on the TCP layer one can specify the port. The default configuration has the following port mappings. Note, that some of the ports are not a standard port because some of the services share the same default port. 
 
 
 | Service               | Port on Ambassador (external)  | Port on Pod (internal) |
@@ -65,12 +65,39 @@ The Ambassador allows the routing on the TCP layer. To signal which service one 
 | Keycloak | 48080 | 80 |
 | App Store | 58080 | 8080 |
 
+To make the access to the Ambassador more user-friendly one can also obtain a domain. The process of buying and managing such a domain is beyond the scope of the documentation. 
+Once, one has a domain availale one can specify it with the value `dns.domain`.
+For the HTTP based services it then also possible to access the services through a subdomain if the public IP of the Ambassador gateway can be accessed with that host name. For example, if you registered and set the domain example.org the subdomain for the app store would be app-store.example.org. By the default the following subdomains exist:
+
+| Service | Subdomain |
+|----------|----------|
+| Grafana | grafana |
+| HTTP Adapter | http-adapter |
+| Hono Device Registry | device-registry |
+| hawkBit | hawkbit |
+| Keycloak | keycloak |
+| App Store | app-store |
 
 
+# TLS 
+To encrypt the traffic from and to the Kuksa cloud one needs to make use of TLS e.g. by using HTTPS. 
 
+## Cert Manager
+For the enablement of TLS one needs valid certificates for the domain under which the endpoints are hosted. In the Kuksa Cloud we use an instance of the [cert-manager](https://cert-manager.io). This tool is able to fetch new certificates and renew them by interacting with an certificate authority e.g. in the case of the standard deployment Let's encrypt.  
 
-The decision which service is called, is signalled through the SNI field in the used certificates. 
-For the creation of these certificates the Kuksa Clouds relies on an instance of the [cert-manager](https://cert-manager.io). 
+## enable and install Cert Manager
+The cert-manager is not enabled by default because we try to make the deployment possible even when no domain or CA is available. To include the cert-manager in the deployment go to the `Chart.yaml` file of the chart and uncomment the dependency `cert-manager`. The cert-manager further requires so-called custom resource definitions (CRD). These are installed with the cert-manager if one sets cert-manager.installCRDs to true. One can also install the CRDs by running: `kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.crds.yaml`
 
-The cert-manager requires so-called custom resource definitions (CRD) which are not installed as part of the Helm chart. To install the CRDs before installing the Helm chart one needs to run: `kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml`
+## Cert Manager: getting certificates - ACME
+The cert-manager is able to automatically request and manage certificates from Let's encrypt through the ACME challenge. The Kuksa Cloud uses the [DNS-01 challenge](https://cert-manager.io/docs/configuration/acme/dns01/). As part of the DNS-01 challenge the cert-manager needs to prove to the CA (e.g. Let's encrypt) that it has control over the DNS entries for the domain for which it requests new certificates. The configuration and execution of the ACME challenge heavily depends on the provider of the DNS entries for the used domain. 
 
+Currently, the cert-manager setup of the Eclipse Kuksa cloud only support the Azure DNS Zone service. However, we especially welcome contributions to add support for other DNS providers. 
+### ACME and Azure
+Within Azure the DNS entries are managed in a `DNS Zone` resource. So to enable the ACME challenge and thus the certificate request the cert-manager needs access to the DNS-Zone for the used domain. Further steps are explained in the [documentation of the cert-manager](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/). In short, you need to create a new Azure service principal, give it the role "DNS Zone Contributor" for the DNS Zone and give the credentials as secret to the cert-manager. In the Helm chart one can set the credentials of the service principal with the values `certificates.azureSpId` and `certificates.azureSpPassword`.
+
+To actually enable the usage of certificates one further needs to set the values `dns.sslForTcpMappings` (for TLS termination on TCP layer) or `dns.sslForHttpMappings` (for TLS termination for HTTP connections) to true.
+
+In our setup we used an Azure `App Service Domain` to buy an domain. But one could also get the domain somewhere else and point it to an DNS Zone in Azure. In either case the situation is so specific to the use case that we decided to not include the creation of the DNS Zone or even a domain into the Azure specific Terraform deployment.  
+
+### Note regarding TLS termination for Keycloak over TCP
+We experienced issues for the connection to Keycloak when terminating the SSL connection on TCP layer on a non-standard port (e.g. 48080). Due to that we decided to disable SSL for the Keycloak connection even if 'sslForTcpMappings' is set to true. You can still enable TLS for the connection to Keycloak when using the HTTP specific subdomain under `keycloak.your-domain` and having `sslForHttpMapping` enabled. If TLS is enabled with the subdomain we then recommend to completly disable the TCP mapping for Keycloak by setting `keycloak.tcpMappingActive` to false to avoid unencypted traffic.

--- a/deployment/helm/kuksa-cloud/Chart.yaml
+++ b/deployment/helm/kuksa-cloud/Chart.yaml
@@ -13,7 +13,6 @@ name: kuksa-cloud
 description: A Helm chart for deploying the core parts of the Eclipse Kuksa cloud to a Kubernetes instance. The Eclipse Kuksa cloud consists of the following parts Eclipse Hono, Eclipse hawkBit, Keycloak, InfluxDb, Kuksa Hono-to-InfluxDb-Connector.
 
 home: https://eclipse.org/kuksa
-#sources: https://github.com/eclipse/kuksa.cloud
 keywords: 
     - IoT
     - Kuksa
@@ -49,4 +48,8 @@ dependencies:
       version: ~6.4.5
       repository: https://www.getambassador.io
       condition: components.ambassador.enabled
+#    - name: cert-manager
+#      version: ~0.15.2
+#      repository: https://charts.jetstack.io
+#      condition: components.cert-manager.enabled
    

--- a/deployment/helm/kuksa-cloud/templates/ambassador/host-keycloak.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/host-keycloak.yaml
@@ -7,15 +7,17 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{if and .Values.components.certmanager.enabled .Values.components.ambassador.enabled .Values.dns.enabled}}
+{{if or .Values.certificates.sslForTcpMappings .Values.certificates.sslForHttpMappings}}
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind: Host
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name: {{.Release.Name}}-host
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  hostname: {{.Values.dns.domain}}
+  acmeProvider:
+    authority: none
+  tlsSecret:
+    name: {{.Release.Name}}-tcp-certificate
+{{end}}
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-appstore.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-appstore.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-app-store
 spec:
   port: 58080
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{.Values.dns.domain}}
+  {{end}}
   service: {{.Release.Name}}-app-store:8080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-device-registry.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-device-registry.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{ .Release.Name }}-device-registry
 spec:
   port: 28080
-  service: {{.Release.Name}}-device-registry-ext:28080
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{ .Values.dns.domain}}
+  {{end}}
+  service: {{.Release.Name}}-service-device-registry-ext:28080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-dispatch-router.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-dispatch-router.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-dispatch-router
 spec:
   port: 5671
+  {{if and .Values.dns.sslForTcpMappings .Values.dns.enabled}}
+  host: {{.Values.certificates.domain}}
+  {{end}}
   service: {{.Release.Name}}-dispatch-router-ext:15671
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-grafana.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-grafana.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-grafana
 spec:
   port: 3000
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{ .Values.dns.domain}}
+  {{end}}
   service: {{.Release.Name}}-grafana:3000
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-hawkbit.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-hawkbit.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-hawkbit
 spec:
   port: 38080
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{.Values.dns.domain}}
+  {{end}}
   service: {{.Release.Name}}-hawkbit:80
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-adapter.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-adapter.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-http-adapter
 spec:
   port: 18080
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{.Values.dns.domain}}
+  {{end}}
   service: {{.Release.Name}}-adapter-http-vertx:8080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-app-store.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-app-store.yaml
@@ -7,15 +7,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
+---
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-app-store
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: app-store.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-app-store:8080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-device-registry.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-device-registry.yaml
@@ -7,15 +7,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-device-registry
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: device-registry.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-service-device-registry-ext:28080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-grafana.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-grafana.yaml
@@ -7,15 +7,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
+---
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-grafana
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: grafana.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-grafana:3000
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-hawkbit.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-hawkbit.yaml
@@ -7,15 +7,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
+---
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-hawkbit
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: hawkbit.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-hawkbit:80
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-http-adapter.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-http-adapter.yaml
@@ -7,15 +7,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-http-adapter
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: http-adapter.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-adapter-http-vertx:8080
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-keycloak.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-http-keycloak.yaml
@@ -7,15 +7,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
+{{ if and .Values.components.ambassador.enabled .Values.dns.enabled }}
 apiVersion: getambassador.io/v2
-kind:  TCPMapping
+kind:  Mapping
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
+  name:  {{.Release.Name}}-http-keycloak
 spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  prefix: /
+  host: keycloak.{{ .Values.dns.domain}}
+  service: {{.Release.Name}}-keycloak-http:80
 {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-influxdb.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-influxdb.yaml
@@ -14,5 +14,8 @@ metadata:
   name:  {{.Release.Name}}-influxdb
 spec:
   port: 8086
+  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
+  host: {{.Values.dns.domain}}
+  {{end}}
   service: {{.Release.Name}}-influxdb:8086
   {{end}}

--- a/deployment/helm/kuksa-cloud/templates/ambassador/mapping-keycloak.yaml
+++ b/deployment/helm/kuksa-cloud/templates/ambassador/mapping-keycloak.yaml
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{- if .Values.components.ambassador.enabled }}
+{{- if and .Values.components.ambassador.enabled .Values.keycloak.tcpMappingActive}}
 apiVersion: getambassador.io/v2
 kind:  TCPMapping
 metadata:

--- a/deployment/helm/kuksa-cloud/templates/cert-manager/azure-issuer.yaml
+++ b/deployment/helm/kuksa-cloud/templates/cert-manager/azure-issuer.yaml
@@ -1,0 +1,39 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{if and .Values.components.certmanager.enabled .Values.components.ambassador.enabled .Values.dns.enabled }}
+{{if or .Values.certificates.sslForTcpMappings .Values.certificates.sslForHttpMappings}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-issuer
+spec:
+  acme:
+    email: {{ .Values.certificates.email }}
+    {{ if .Values.certificates.productionCertificate}}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    {{ else }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    {{ end }}
+    privateKeySecretRef:
+        name: issuer-key
+    solvers:
+    - dns01:
+        azuredns:
+          clientID: {{ .Values.certificates.azureSpId }}
+          clientSecretSecretRef:
+            name: {{ .Release.Name}}-dns-zone-service-principal-secret
+            key: sp_pw
+          subscriptionID: {{ .Values.certificates.azureSubscriptionId }}
+          tenantID: {{ .Values.certificates.azureTenantId }}
+          resourceGroupName: {{ .Values.certificates.azureResourceGroup }}
+          hostedZoneName: {{ .Values.dns.domain}}
+          environment: AzurePublicCloud
+{{end}}
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/cert-manager/certificates-tcp.yaml
+++ b/deployment/helm/kuksa-cloud/templates/cert-manager/certificates-tcp.yaml
@@ -1,0 +1,30 @@
+######################################################################
+# Copyright (c) 2020 Bosch.IO GmbH [and others]
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+{{if and .Values.components.certmanager.enabled .Values.components.ambassador.enabled .Values.dns.enabled}}
+{{if or .Values.certificates.sslForTcpMappings .Values.certificates.sslForHttpMappings}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ .Release.Name}}-tcp-certificate
+spec:
+  secretName: {{ .Release.Name}}-tcp-certificate
+  issuerRef:
+    name: {{ .Release.Name }}-issuer
+    kind: Issuer
+  dnsNames:
+  - {{ .Values.dns.domain }}
+  - app-store.{{.Values.dns.domain}}
+  - device-registry.{{.Values.dns.domain}}
+  - grafana.{{.Values.dns.domain}}
+  - hawkbit.{{.Values.dns.domain}}
+  - http-adapter.{{.Values.dns.domain}}
+  - keycloak.{{.Values.dns.domain}}
+{{end}}
+{{end}}

--- a/deployment/helm/kuksa-cloud/templates/cert-manager/dns_principal_secret.yaml
+++ b/deployment/helm/kuksa-cloud/templates/cert-manager/dns_principal_secret.yaml
@@ -7,15 +7,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
-{{ if .Values.components.ambassador.enabled }}
-apiVersion: getambassador.io/v2
-kind:  TCPMapping
+{{if and .Values.components.certmanager.enabled .Values.components.ambassador.enabled .Values.dns.enabled}}
+{{if or .Values.certificates.sslForTcpMappings .Values.certificates.sslForHttpMappings}}
+apiVersion: v1
+kind: Secret
 metadata:
-  name:  {{.Release.Name}}-adapter-mqtt
-spec:
-  port: 1883
-  {{if and .Values.certificates.sslForTcpMappings .Values.dns.enabled}}
-  host: {{ .Values.dns.domain}}
-  {{end}}
-  service: {{.Release.Name}}-adapter-mqtt-vertx:1883
+  name: {{ .Release.Name }}-dns-zone-service-principal-secret
+type: Opaque
+data:
+  sp_pw: "{{- printf .Values.certificates.azureSpPassword | b64enc }}"
+{{end}}
 {{end}}

--- a/deployment/helm/kuksa-cloud/values.yaml
+++ b/deployment/helm/kuksa-cloud/values.yaml
@@ -13,6 +13,11 @@ imageCredentials:
   username: 
   password: 
 
+# sets the domain for the hosts used for the API gateway (Ambassador)
+dns:
+  domain: example.org
+  enabled: false
+
 # configure the Hono-InfluxDB-Connector
 connector:
   # The name of the container image for the connector. Note that the address of the container registry under imageCredentials.registry is added as prefix and that the image should be tagged with the App version of this chart.
@@ -68,6 +73,8 @@ components:
     enabled: true
   ambassador:
     enabled: true
+  certmanager:
+    enabled: false
 
 # configure the values from the Eclipse Hono Helm chart fetched from https://github.com/eclipse/packages/tree/master/charts/hono
 hono:
@@ -80,6 +87,7 @@ hono:
 
 # configure the values from the Keycloak chart fetched from https://github.com/codecentric/helm-charts/tree/master/charts/keycloak
 keycloak:
+  tcpMappingActive: true
   keycloak:
     username: keycloak
     password: admin
@@ -103,4 +111,18 @@ ambassador:
     loadBalancerIP: localhost
     # The annotations are specific to the Cloud provider (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer ). The default annotation in this chart is suited for Azure to allow the assignment of an Azure managed IP-address to the LoadBalancer service of the Ambassador. One needs to replace "kuksa" with the actual name of the resource group of the IP-address assigned in 'loadBalancerIP' and allow the service principle for the AKS to access the IP-address. For more information see https://docs.microsoft.com/en-us/azure/aks/static-ip. 
     annotations: 
-      service.beta.kubernetes.io/azure-load-balancer-resource-group: "kuksa"
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: "azure-resource-group"
+
+    cert-manager:
+      installCRDs: true
+
+    #The cert manager is used to request certificates from Let's encrypt using ACME with a DNS-01 challeng. For more information visit https://cert-manager.io/docs/configuration/acme/dns01/ or consult the Readme file. For this Chart we assume that the Kuksa Cloud is hosted in an Azure environment. An introduction of the required information for the ACME challenge in Azure and how to obtain those values is available under: https://cert-manager.io/docs/configuration/acme/dns01/azuredns/. If you are using another environment for managing your DNS entries, you need to adapt the respective issuer in templates/cert-manager.
+    certificates:
+      productionCertificate: false
+      sslForTcpMappings: false
+      sslForHttpMappings: false
+      azureSubscriptionId: 
+      azureTenantId: 
+      azureResourceGroup: 
+      azureSpId: 
+      azureSpPassword: 


### PR DESCRIPTION
Adding support for TLS connection enabled by certificates obtained from Let's encrypt through an instance of the cert-manager project. 