### PR TITLE
updates Helm chart to use app version 1.4 of Eclipse Hono

### DIFF
--- a/deployment/helm/kuksa-cloud/Chart.yaml
+++ b/deployment/helm/kuksa-cloud/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
 
 dependencies:
     - name: hono
-      version: ~1.1.3
+      version: ~1.3.19
       repository: https://eclipse.org/packages/charts
       condition: components.hono.enabled
     - name: influxdb


### PR DESCRIPTION
Updates the used chart version for the Eclipse Hono chart to update the used app version of Eclipse Hono to 1.4