### PR TITLE
update hono dependency support event messages

### DIFF
--- a/utils/hono-influxdb-connector/build.gradle
+++ b/utils/hono-influxdb-connector/build.gradle
@@ -22,7 +22,7 @@ version = '0.2.0'
 mainClassName = 'org.eclipse.kuksa.honoConnector.HonoInfluxConnectorApplication'
 
 dependencies {
-    compile 'org.eclipse.hono:hono-client:1.2.2'
+    compile 'org.eclipse.hono:hono-client-application-amqp:1.8.0'
     compile 'org.springframework.boot:spring-boot-starter:2.1.3.RELEASE'
     compile 'org.influxdb:influxdb-java:2.14'
     testCompile 'junit:junit:4.12'

--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/influxdb/InfluxDBClient.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2021 Bosch.IO GmbH [and others]
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,6 +10,7 @@
  *  Contributors:
  *      Johannes Kristan (Bosch Software Innovations GmbH) - initial API and functionality
  *      Leon Graser (Bosch Software Innovations GmbH)
+ *      others
  * *****************************************************************************
  */
 
@@ -17,6 +18,7 @@ package org.eclipse.kuksa.honoConnector.influxdb;
 
 import org.eclipse.kuksa.honoConnector.message.MessageDTO;
 import org.eclipse.kuksa.honoConnector.message.MessageHandler;
+import org.eclipse.kuksa.honoConnector.message.MessageTypes;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBException;
 import org.influxdb.InfluxDBFactory;
@@ -106,7 +108,22 @@ public class InfluxDBClient implements MessageHandler {
      * @param msg message dto to process
      */
     @Override
+    @Deprecated
     public void process(final MessageDTO msg) {
+        process(msg, MessageTypes.MISCELLANEOUS);
+    }
+
+    @Override
+    public void processTelemetry(MessageDTO msg) {
+        process(msg, MessageTypes.TELEMETRY);
+    }
+
+    @Override
+    public void processEvent(MessageDTO msg) {
+        process(msg, MessageTypes.EVENT);
+    }
+
+    private void process(final MessageDTO msg, MessageTypes messageType) {
         // check for empty messages and just drop them
         if (msg == null) {
             return;
@@ -127,8 +144,15 @@ public class InfluxDBClient implements MessageHandler {
             LOGGER.debug("Generated timestamp: {} for message with sender: {}", timestamp, msg.getDeviceID());
         }
 
-        final Point point = createPoint(timestamp, msg.getDeviceID(), entries);
-		writePoint(point);
+        String measurement = msg.getDeviceID();
+        if (messageType.equals(MessageTypes.TELEMETRY)) {
+            measurement += "_telemetry";
+        } else if (messageType.equals(MessageTypes.EVENT)) {
+            measurement += "_event";
+        }
+
+        final Point point = createPoint(timestamp, measurement, entries);
+        writePoint(point);
     }
 
     public static Point createPoint(long timestampMs, final String deviceID, final Map<String, Object> entries) {

--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageHandler.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageHandler.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ * Copyright (c) 2021 Bosch.IO GmbH [and others]
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *      Johannes Kristan (Bosch Software Innovations GmbH) - initial API and functionality
+ *      others
  * ******************************************************************************
  */
 
@@ -24,7 +25,22 @@ public interface MessageHandler {
      *
      * @param msg message dto to process
      */
+    @Deprecated
     void process(final MessageDTO msg);
+
+    /**
+     * Processes the incoming telemetry message dto received from Hono.
+     *
+     * @param msg message dto to process
+     */
+    void processTelemetry(final MessageDTO msg);
+
+    /**
+     * Processes the incoming event message dto received from Hono.
+     * @param msg
+     */
+    void processEvent(final MessageDTO msg);
+
 
     /**
      * Closes the message handler. Needs to be called before exit.

--- a/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageTypes.java
+++ b/utils/hono-influxdb-connector/src/main/java/org/eclipse/kuksa/honoConnector/message/MessageTypes.java
@@ -1,0 +1,18 @@
+/*
+ *********************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH [and others]
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.kuksa.honoConnector.message;
+
+public enum MessageTypes {
+    TELEMETRY,
+    EVENT,
+    MISCELLANEOUS
+}


### PR DESCRIPTION
Adds the processing of Hono event messages to the connector. In addition, changes the hono client dependency as the previous one has been deprected by the Hono project.
    Closes #172